### PR TITLE
PR | From org repo | 25.09.2023 

### DIFF
--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -14,7 +14,7 @@ const defaultOptions: Options = {
 
 function coerceDate(fp: string, d: any): Date {
   const dt = new Date(d)
-  const invalidDate = isNaN(dt.getTime())
+  const invalidDate = isNaN(dt.getTime()) || dt.getTime() === 0
   if (invalidDate && d !== undefined) {
     console.log(
       chalk.yellow(


### PR DESCRIPTION
fix: treat the 0 time as invalid too